### PR TITLE
Added endpoint to allow uploading donations

### DIFF
--- a/db/migrations/20191109095405-create-donors.js
+++ b/db/migrations/20191109095405-create-donors.js
@@ -9,6 +9,7 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       idNo: {
+        unique: true,
         allowNull: true,
         type: Sequelize.STRING
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2772,8 +2772,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2794,14 +2793,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2816,20 +2813,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2946,8 +2940,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2959,7 +2952,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2974,7 +2966,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2982,14 +2973,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3008,7 +2997,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3089,8 +3077,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3102,7 +3089,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3188,8 +3174,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3225,7 +3210,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3245,7 +3229,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3289,14 +3272,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4853,6 +4834,11 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "~4.16.1",
     "express-session": "^1.16.2",
     "jsonwebtoken": "^8.5.1",
+    "lodash.uniqby": "^4.7.0",
     "morgan": "^1.9.1",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",

--- a/src/models/donation.js
+++ b/src/models/donation.js
@@ -25,13 +25,11 @@ module.exports = (sequelize, DataTypes) => {
     });
 
     Donation.hasOne(models.Source, {
-      foreignKey: 'sourceId',
-      as: 'source'
+      foreignKey: 'id'
     });
 
     Donation.hasOne(models.PaymentType, {
-      foreignKey: 'paymentTypeId',
-      as: 'paymentType'
+      foreignKey: 'id'
     });
 
     Donation.hasOne(models.Intent, {

--- a/src/models/donor.js
+++ b/src/models/donor.js
@@ -1,10 +1,11 @@
-'use strict';
+'use strict'
 
 // const { Donation } = require("../../src/models");
 
 module.exports = (sequelize, DataTypes) => {
   const Donor = sequelize.define('Donor', {
-    idNo: DataTypes.INTEGER,
+    id: { type: DataTypes.INTEGER, primaryKey: true },
+    idNo: { type: DataTypes.STRING, unique: true },
     idTypeId: DataTypes.INTEGER,
     salutationId: DataTypes.STRING,
     name: DataTypes.STRING,
@@ -13,12 +14,12 @@ module.exports = (sequelize, DataTypes) => {
     address1: DataTypes.STRING,
     address2: DataTypes.STRING,
     postalCode: DataTypes.INTEGER,
-    preferedContactId: DataTypes.INTEGER,
+    preferredContactId: DataTypes.INTEGER,
     dnc: DataTypes.BOOLEAN,
     dateofBirth: DataTypes.DATE,
     remarks: DataTypes.STRING,
     contactPersonId: DataTypes.INTEGER
-  }, {});
+  },{})
 
   Donor.associate = function(models) {
     // associations can be defined here
@@ -26,28 +27,26 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'donorId',
       allowNull: true,
       as: 'donations'
-    });
+    })
 
     Donor.hasOne(models.PreferredContact, {
-      foreignKey: 'preferedContactId',
+      foreignKey: 'preferredContactId',
       as: 'preferredContact'
-    });
+    })
 
     Donor.hasOne(models.Salutation, {
       foreignKey: 'id'
-    });
+    })
 
     Donor.hasOne(models.IdType, {
-      foreignKey: 'idTypeId',
-      as: 'idType'
-    });
+      foreignKey: 'id'
+    })
 
     Donor.hasOne(models.ContactPerson, {
       foreignKey: 'contactPersonId',
       as: 'contactPerson'
-    });
+    })
+  }
 
-  };
-
-  return Donor;
-};
+  return Donor
+}

--- a/src/routes/donations.js
+++ b/src/routes/donations.js
@@ -1,12 +1,242 @@
-const express = require('express');
-const router = express.Router();
+const express = require('express')
+const router = express.Router()
+const db = require('../models/index')
+const uniqBy = require('lodash.uniqby')
 
 /* GET Donations records. */
-router.get('/', function (req, res, next) {
-  const { start, end } = req.query;
-  console.log(req.query);
-  res.status(200).json({});
-});
+router.get('/', function(req, res, next) {
+  const { start, end } = req.query
+  console.log(req.query)
+  res.status(200).json({})
+})
 
+router.post('/upload', (req, res) => {
+  return db.sequelize.transaction(t => {
+    return _createCaches()
+      .then(caches => {
+        return req.body.map(donationWithDonor => {
+          _validateIncomingDonor(donationWithDonor)
+          _validateIncomingDonation(donationWithDonor)
+          // Doing this because they're independent queries and I want to blast through them as fast as possible with a Promise.all
+          const foreignQueries = []
+          foreignQueries[0] = caches.salutationsCache.findOrCreate(
+            donationWithDonor.Salutation
+          )
+          foreignQueries[1] = caches.idTypeCache.findOrCreate(
+            donationWithDonor['ID Type']
+          )
+          foreignQueries[2] = caches.sourceCache.findOrCreate(
+            donationWithDonor.Project
+          )
+          foreignQueries[3] = caches.paymentTypeCache.findOrCreate(
+            donationWithDonor['Type of Payment']
+          )
 
-module.exports = router;
+          return previousResult =>
+            Promise.all(foreignQueries).then(
+              ([salutationId, idTypeId, sourceId, paymentTypeId]) => {
+                const donation = {
+                  ..._buildDonation(donationWithDonor),
+                  sourceId,
+                  paymentTypeId
+                }
+                const donor = {
+                  ..._buildDonor(donationWithDonor),
+                  idTypeId,
+                  salutationId
+                }
+                return _upsertDonorInsertDonation({
+                  donor,
+                  donation,
+                  transation: t,
+                  previousResult
+                })
+              }
+            )
+        })
+      })
+      .then(promises => {
+        return promises.reduce((previousPromise, nextPromise) => {
+          return previousPromise.then(_ => nextPromise(_))
+        }, Promise.resolve([]))
+      })
+      .then(results => {
+        const deduped = _dedupeDonors(results)
+        res.status(200).send(deduped)
+      })
+      .catch(e => {
+        console.log(e)
+        _handleError(res, e)
+      })
+  })
+})
+
+module.exports = router
+
+/*** Utils ***/
+
+/**
+ * Fetches all existing salutations, idTypes, sources and payment types
+ * and loads them in memory so we reduce the number of DB hits.
+ */
+function _createCaches() {
+  const salutationsCache = _simpleCache(db.Salutation)
+  const idTypeCache = _simpleCache(db.IdType)
+  const sourceCache = _simpleCache(db.Source)
+  const paymentTypeCache = _simpleCache(db.PaymentType)
+  return Promise.all([
+    salutationsCache.populate(),
+    idTypeCache.populate(),
+    sourceCache.populate(),
+    paymentTypeCache.populate()
+  ]).then(() => {
+    return {
+      salutationsCache,
+      idTypeCache,
+      sourceCache,
+      paymentTypeCache
+    }
+  })
+}
+
+/**
+ * "Cache" to load all records of a particular model in memory, then
+ * return the ID from memory, or create the new record and return
+ * the newly-created ID
+ */
+function _simpleCache(Model) {
+  return {
+    data: {},
+    populate() {
+      return Model.findAll().then(items => {
+        const obj = items.reduce((cache, model) => {
+          cache[model.description] = model.id
+          return cache
+        }, {})
+        this.data = obj
+        return this
+      })
+    },
+    findOrCreate(description) {
+      if (!description) return Promise.resolve()
+      const found = this.data[description]
+      if (found) {
+        return Promise.resolve(found)
+      }
+      return Model.create({
+        description
+      }).then(model => {
+        this.data[description] = model.id
+        return model.id
+      })
+    }
+  }
+}
+
+function _buildDonation(csvDonation) {
+  return {
+    donationDate: csvDonation['Date of Donation'],
+    donationAmount: csvDonation['Amount'],
+    donationType: csvDonation['Type of Donation'],
+    remarks: csvDonation['Remarks'],
+    receiptNo: csvDonation['Receipt Serial No'],
+    void: csvDonation['Void'],
+    taxDeductible: csvDonation['Tax Deductible'] || false
+  }
+}
+
+function _buildDonor(csvDonation) {
+  return {
+    idNo: csvDonation['ID No'] || null,
+    name: csvDonation['Name'],
+    email: csvDonation['Email Address'],
+    contactNo: csvDonation['Tel No'],
+    address1: csvDonation['Add 1'],
+    address2: csvDonation['Add 2'],
+    postalCode: csvDonation['Postal Code']
+  }
+}
+
+/**
+ * Helper to sequentially upsert a Donor then insert a Donation
+ */
+function _upsertDonorInsertDonation({
+  donor,
+  donation,
+  transaction,
+  previousResult
+}) {
+  return db.Donor.upsert(donor, {
+    transaction,
+    returning: true
+  }).then(([donor, created]) => {
+    return new Promise(res => {
+      return db.Donation.create({
+        ...donation,
+        donorId: donor.id
+      }, {
+        transaction
+      }).then(() =>
+        res([...previousResult, { ...donor.toJSON(), __isNew: created }])
+      )
+    })
+  })
+}
+
+function _validateIncomingDonor(incoming) {
+  // Nothing here yet
+}
+function _validateIncomingDonation(incoming) {
+  if (!incoming['Receipt Serial No']) {
+    throw new ValidationError('Missing field in Donation: Receipt Serial No')
+  }
+}
+
+/* The upload can contain multiple donations by the same donor.
+ * This dedupes them, also making sure that if a donor was
+ * created and then updated in the same upload,
+ * they are marked as a *new* donor.
+ */
+function _dedupeDonors(results) {
+  return uniqBy(results, donor => donor.id && donor.__isNew).reduce(
+    (donors, donor) => {
+      const idx = donors.findIndex(d => d.id === donor.id)
+      if (idx < 0) {
+        // have not encountered this donor yet
+        donors.push(donor)
+      } else if (donors[idx].__isNew && !donor.__isNew) {
+        // existing is new, incoming is updated:
+        // take updated details and mark as new
+        donors[idx] = donor
+        donors[idx].__isNew = true
+      } else {
+        // we should not reach here
+        donors[idx] = donor
+      }
+      return donors
+    },
+    []
+  )
+}
+
+function _handleError(res, e) {
+  switch (e.constructor) {
+    case ValidationError: {
+      return res
+        .status(400)
+        .send({ message: e.message, errorType: 'ValidationError' })
+    }
+    default: {
+      return res
+        .status(500)
+        .send({ message: 'Server Error', errorType: 'Unknown Error' })
+    }
+  }
+}
+
+class ValidationError extends Error {
+  constructor(...params) {
+    super(...params)
+    this.name = 'ValidationError'
+  }
+}

--- a/src/routes/donations.js
+++ b/src/routes/donations.js
@@ -48,7 +48,7 @@ router.post('/upload', (req, res) => {
                 return _upsertDonorInsertDonation({
                   donor,
                   donation,
-                  transation: t,
+                  transaction: t,
                   previousResult
                 })
               }


### PR DESCRIPTION
Closes #13 

## Upload Donations Endpoint (`/donations/upload`)
This endpoint accepts an array of objects each representing a "Donation with Donor". Since the data is coming from a CSV file, each object will contain both donation and donor fields. The endpoint will create separate Donor and Donation objects then upsert the Donors and create the Donations.

Rough outline of what is happening:

- Load all the Salutations, Payment Type, Sources and ID Type records in-memory. This is so we can get the respective IDs without excessive trips to the DB.
- For each uploaded record *:
  - Build the Donor and Donation models.
  - Upsert the Donor, then insert the Donation.
- Derive the number of created vs. updated Donors.
- Return an array of Donor objects, with each object having an extra `__isNew` field to represent if the donor was created or updated.

\* Step 2 occurs sequentially.

### Schema Changes
Made the Donor `donorId` unique. This is to allow the upsert to correctly identify repeat donors.