### PR TITLE
Update Donor remarks/preferredContactId

### DIFF
--- a/src/models/donor.js
+++ b/src/models/donor.js
@@ -30,8 +30,7 @@ module.exports = (sequelize, DataTypes) => {
     })
 
     Donor.hasOne(models.PreferredContact, {
-      foreignKey: 'preferredContactId',
-      as: 'preferredContact'
+      foreignKey: 'id'
     })
 
     Donor.hasOne(models.Salutation, {


### PR DESCRIPTION
This allows editing either the donor `remarks` or the `preferredContactId` (or both).

### `PUT - /donors/updatedonors/:id`
```json
{
  "remarks": "Test remark",
  "preferredContact": "Phone Number"
}
```

- If you pass neither any `remarks`, nor a `preferredContact`, it will not do anything.
- It ignores falsy values for `remarks` or `preferredContact`. E.g. if you pass an empty string in `remarks`, no update to `remarks` will be made.
- For the `preferredContact`, it expects the text description (e.g. "Phone Number"). The endpoint will query for the appropriate ID and update the Donor model. If no record is found for the description given, it will *not* update the `preferredContactId`. This is because from the UI, the preferred contact type is selected from a radio group, so the possible options should be well-known (i.e. no need to do a `findOrCreate`).