### PR TITLE
Fixed concurrency bug with simple cache

### DIFF
--- a/src/routes/donations.js
+++ b/src/routes/donations.js
@@ -85,21 +85,21 @@ router.post('/upload', (req, res) => {
           _validateIncomingDonation(donationWithDonor)
           // Doing this because they're independent queries and I want to blast through them as fast as possible with a Promise.all
           const foreignQueries = []
-          foreignQueries[0] = caches.salutationsCache.findOrCreate(
-            donationWithDonor.Salutation
+          foreignQueries[0] = _donationWithDonor => caches.salutationsCache.findOrCreate(
+            _donationWithDonor.Salutation
           )
-          foreignQueries[1] = caches.idTypeCache.findOrCreate(
-            donationWithDonor['ID Type']
+          foreignQueries[1] = _donationWithDonor => caches.idTypeCache.findOrCreate(
+            _donationWithDonor['ID Type']
           )
-          foreignQueries[2] = caches.sourceCache.findOrCreate(
-            donationWithDonor.Project
+          foreignQueries[2] = _donationWithDonor => caches.sourceCache.findOrCreate(
+            _donationWithDonor.Project
           )
-          foreignQueries[3] = caches.paymentTypeCache.findOrCreate(
-            donationWithDonor['Type of Payment']
+          foreignQueries[3] = _donationWithDonor => caches.paymentTypeCache.findOrCreate(
+            _donationWithDonor['Type of Payment']
           )
 
           return previousResult =>
-            Promise.all(foreignQueries).then(
+            Promise.all(foreignQueries.map(fq => fq(donationWithDonor))).then(
               ([salutationId, idTypeId, sourceId, paymentTypeId]) => {
                 const donation = {
                   ..._buildDonation(donationWithDonor),


### PR DESCRIPTION
Fixes #31 

- The simple cache findOrCreate method was being called outside of the "sequentially resolved" promise chain
  - It was being called at Lines 88 (salutation), 91 (ID type), 94 (project), 97 (payment type).
- This means that sometimes one instance of the method invocation was being called before the previous ended.
- This means that sometimes the second instance thought a value was missing from the cache, but it was in the process of being added by the previous invocation.
- This change moves the invocation of the findOrCreate method inside the sequential promise chain, meaning as each record is evaluated, all operations from the previous record have completed.
  - It changes the method calls at Lines 88, 91, 94, 97 to functions, and calls these functions _inside_ the sequential promise chain, which is at Line 101.

Thanks to @clukhei for discovering this issue.