### PR TITLE
Allow the upload endpoint to accept existing donations.

### DIFF
--- a/src/models/donation.js
+++ b/src/models/donation.js
@@ -14,7 +14,7 @@ module.exports = (sequelize, DataTypes) => {
     paymentRef: DataTypes.STRING,
     taxDeductible: DataTypes.BOOLEAN,
     remarks: DataTypes.STRING,
-    receiptNo: DataTypes.STRING,
+    receiptNo: { type: DataTypes.STRING, unique: true },
     void: DataTypes.BOOLEAN
   }, {});
   Donation.associate = function(models) {

--- a/src/routes/donations.js
+++ b/src/routes/donations.js
@@ -255,7 +255,7 @@ function _upsertDonorInsertDonation({
     returning: true
   }).then(([donor, created]) => {
     return new Promise(res => {
-      return db.Donation.create(
+      return db.Donation.upsert(
         {
           ...donation,
           donorId: donor.id


### PR DESCRIPTION
This is achieved by marking the receiptNo as unique and do an upsert on the donation inside the upload route handler.