### PR TITLE
allow search to be case insensitive by using Op.iLike

### DIFF
--- a/src/routes/donors.js
+++ b/src/routes/donors.js
@@ -246,12 +246,12 @@ router.get('/search', function(req, res) {
     db.Donor.findAll({
       where: {
         name: {
-          [db.Sequelize.Op.like]: `%${req.query.name}%`
+          [db.Sequelize.Op.iLike]: `%${req.query.name}%`
         }
       },
       attributes: ['idNo', 'name', 'contactNo', 'email', 'dnc']
     }).then(donorObj => {
-      res.json(donorObj)
+      res.status(200).json(donorObj)
     })
   } catch (err) {
     res.status(500).json(err)


### PR DESCRIPTION
Using zoe as an example, 

-Previously, with Op.like, search does not recognized "zoe" , it only recognizes "Zoe" (same for other names). 

-Using Op.iLike instead will enable search to be case insensitive. 

- changed   res.json(donorObj) to res.status(200).json(donorObj) because with Op.iLike I got caanot set header after sent error
![image](https://user-images.githubusercontent.com/55618945/76732741-5c563700-679a-11ea-9c0d-efd1dd6ed49a.png)


- Using res.status(200).json(donorObj) resolves this error. I think it tells express that it is in the finished state and stop anything that tries to res.setHeader again. Not really sure about this but saw some answers from this link which got me to try res.status(200).json(donorObj) instead. 

But Im not sure why previously with Op.like it can work with res.json(donorObj)

https://stackoverflow.com/questions/7042340/error-cant-set-headers-after-they-are-sent-to-the-client?answertab=active#tab-top

please enlighten me :) 

