### PR TITLE
 middleware modifications: increase maximum req body size

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,8 +17,8 @@ const app = express()
 
 app.use(cors())
 app.use(logger('dev'))
-app.use(express.json())
-app.use(express.urlencoded({ extended: false }))
+app.use(express.json({limit: '50mb'}));
+app.use(express.urlencoded({ limit: '50mb', extended: false }))
 app.use(cookieParser())
 app.use(passport.initialize());
 

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,7 @@ const app = express()
 
 app.use(cors())
 app.use(logger('dev'))
-app.use(express.json({limit: '50mb'}));
+app.use(express.json({limit: '2mb'}));
 app.use(express.urlencoded({ limit: '50mb', extended: false }))
 app.use(cookieParser())
 app.use(passport.initialize());


### PR DESCRIPTION
Hello 

REACH peeps has tested the upload IPC file feature and they face errors during upload. 
They uploaded a file that has 1500 + entries 
![image](https://user-images.githubusercontent.com/55618945/84521116-25df7800-ad07-11ea-8ed7-724cbbd9f731.png)

On heroku logs , it turns out that the error occurred due to payLoadTooLargeError 
![image](https://user-images.githubusercontent.com/55618945/84521263-51faf900-ad07-11ea-9cc8-9d5308fa2557.png)

I created a dummy file with 1500+ entries and was able to replicate the same error. 
File size : 246 KiB
So I increased the limit of maximum req body size to 50MiB, now upload works well.

50 MiB = 51200 KiB 

51200/246 * 1500 = 3+ million IPC excel rows 

Just wondering if increasing limit to 50MiB is too much?

reference: https://stackoverflow.com/questions/19917401/error-request-entity-too-large
